### PR TITLE
🔒 Restrict API key creation to authenticated users

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
     'youtube_api.apps.YoutubeApiConfig'
 ]
 

--- a/youtube_api/tests.py
+++ b/youtube_api/tests.py
@@ -1,6 +1,9 @@
 from django.test import TestCase, Client
 from django.urls import reverse
+from django.contrib.auth import get_user_model
 from . import models
+
+User = get_user_model()
 
 class VideoAPITests(TestCase):
 
@@ -29,3 +32,27 @@ class VideoAPITests(TestCase):
         # or specific keys if data is expected. For a basic test, status 200 is sufficient.
         # For example, if it's okay for it to return an empty list initially:
         # self.assertEqual(response.json().get('results', []), [])
+
+class SecurityTests(TestCase):
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(username='testuser', password='testpassword')
+        # Based on project structure: /youtube_api/add_key
+        try:
+            self.url = reverse('youtube_api:add_key')
+        except: # noqa
+            self.url = '/youtube_api/add_key'
+
+    def test_add_api_key_unauthenticated(self):
+        """Test that unauthenticated requests to add_key are rejected."""
+        response = self.client.post(self.url, {'key': 'new_test_key'})
+        # DRF returns 403 Forbidden for IsAuthenticated failure by default
+        self.assertEqual(response.status_code, 403)
+
+    def test_add_api_key_authenticated(self):
+        """Test that authenticated requests to add_key are accepted."""
+        self.client.login(username='testuser', password='testpassword')
+        response = self.client.post(self.url, {'key': 'new_test_key'})
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(models.APIKey.objects.filter(key='new_test_key').exists())

--- a/youtube_api/views.py
+++ b/youtube_api/views.py
@@ -2,6 +2,7 @@ from django import forms
 from rest_framework import generics, exceptions
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.renderers import JSONRenderer
+from rest_framework.permissions import IsAuthenticated
 
 from . import models
 from . import serializers
@@ -33,3 +34,4 @@ class AddAPIKey(generics.CreateAPIView):
     """
     renderer_classes = [JSONRenderer]
     serializer_class = serializers.APIKeySerializer
+    permission_classes = [IsAuthenticated]


### PR DESCRIPTION
### 🎯 What:
Fixed the unrestricted API key creation vulnerability in the `AddAPIKey` view.

### ⚠️ Risk:
Leaving this endpoint unrestricted allowed anyone to add API keys to the database. This could be exploited to:
- Fill the database with malicious or invalid keys.
- Monitor the search queries being made by the background service.
- Exhaust quotas of added keys.

### 🛡️ Solution:
- Enforced `IsAuthenticated` permission on the `AddAPIKey` view.
- Added Django REST Framework to `INSTALLED_APPS` for proper permission handling.
- Implemented automated tests to verify the security restriction.

---
*PR created automatically by Jules for task [11299117124131459848](https://jules.google.com/task/11299117124131459848) started by @bhushanchinmay*