### PR TITLE
🧹 Remove hardcoded URL in tests and use named URL patterns

### DIFF
--- a/youtube_api/tests.py
+++ b/youtube_api/tests.py
@@ -9,18 +9,8 @@ class VideoAPITests(TestCase):
         models.APIKey.objects.create(key="test_key")
 
     def test_get_videos_endpoint_success(self):
-        # Try to reverse the URL name if it's defined, otherwise use the hardcoded path
-        try:
-            # Assuming 'get_videos' is the name in youtube_api.urls.py
-            # and 'youtube_api' is the app_name or namespace for the app
-            url = reverse('youtube_api:get_videos')
-        except: # noqa
-            # If reverse fails (e.g., name not set or app namespace needed),
-            # construct path manually.
-            # Based on project structure: path('youtube_api/', include('youtube_api.urls')) in api/urls.py
-            # and in youtube_api.urls: path('get_videos', views.GetVideos.as_view(), name='get_videos')
-            # So, the full path is /youtube_api/get_videos
-            url = '/youtube_api/get_videos' # Ensure no trailing slash
+        # Use reverse() with the named URL pattern
+        url = reverse('youtube_api:get_videos')
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)

--- a/youtube_api/urls.py
+++ b/youtube_api/urls.py
@@ -3,9 +3,11 @@ from django.urls import path
 from . import services
 from . import views
 
+app_name = 'youtube_api'
+
 urlpatterns = [
-    path('get_videos', views.GetVideos.as_view()),
-    path('add_key', views.AddAPIKey.as_view()),
+    path('get_videos', views.GetVideos.as_view(), name='get_videos'),
+    path('add_key', views.AddAPIKey.as_view(), name='add_key'),
 ]
 
 # services.THREAD.start() # Moved to AppConfig


### PR DESCRIPTION
The task was to fix a hardcoded URL in `youtube_api/tests.py`. I have implemented Django's named URL pattern system by adding an `app_name` to the app's `urls.py` and naming the relevant paths. I then updated the test to use `reverse()` to dynamically generate the URL, removing the fragile hardcoded string and its associated fallback logic.

---
*PR created automatically by Jules for task [14996468006251819783](https://jules.google.com/task/14996468006251819783) started by @bhushanchinmay*