### PR TITLE
🔒 [security fix] Secure AddAPIKey endpoint with IsAuthenticated

### DIFF
--- a/youtube_api/tests.py
+++ b/youtube_api/tests.py
@@ -1,12 +1,16 @@
 from django.test import TestCase, Client
 from django.urls import reverse
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
 from . import models
 
 class VideoAPITests(TestCase):
 
     def setUp(self):
         self.client = Client()
+        self.api_client = APIClient()
         models.APIKey.objects.create(key="test_key")
+        self.user = get_user_model().objects.create_user(username='testuser', password='password')
 
     def test_get_videos_endpoint_success(self):
         # Try to reverse the URL name if it's defined, otherwise use the hardcoded path
@@ -29,3 +33,20 @@ class VideoAPITests(TestCase):
         # or specific keys if data is expected. For a basic test, status 200 is sufficient.
         # For example, if it's okay for it to return an empty list initially:
         # self.assertEqual(response.json().get('results', []), [])
+
+    def test_add_api_key_unauthenticated(self):
+        # Using hardcoded path based on urls.py structure as in test_get_videos_endpoint_success
+        url = '/youtube_api/add_key'
+        data = {'key': 'new_test_key'}
+        response = self.api_client.post(url, data, format='json')
+        # Expecting 401 Unauthorized or 403 Forbidden because of IsAuthenticated
+        self.assertIn(response.status_code, [401, 403])
+        self.assertFalse(models.APIKey.objects.filter(key='new_test_key').exists())
+
+    def test_add_api_key_authenticated(self):
+        url = '/youtube_api/add_key'
+        data = {'key': 'new_test_key'}
+        self.api_client.force_authenticate(user=self.user)
+        response = self.api_client.post(url, data, format='json')
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(models.APIKey.objects.filter(key='new_test_key').exists())

--- a/youtube_api/views.py
+++ b/youtube_api/views.py
@@ -1,5 +1,5 @@
 from django import forms
-from rest_framework import generics, exceptions
+from rest_framework import generics, exceptions, permissions
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.renderers import JSONRenderer
 
@@ -31,5 +31,6 @@ class AddAPIKey(generics.CreateAPIView):
     """view for adding a new Youtube Data API Key in the database.
 
     """
+    permission_classes = [permissions.IsAuthenticated]
     renderer_classes = [JSONRenderer]
     serializer_class = serializers.APIKeySerializer


### PR DESCRIPTION
🎯 **What:** The `AddAPIKey` endpoint was missing authentication, allowing unauthenticated users to create YouTube API keys in the database via POST requests.

⚠️ **Risk:** Anyone could inject or manipulate the API keys used by the background application. This could be abused to insert an invalid key that breaks functionality or a malicious key that somehow causes quota usage on the attacker's behalf (or simply pollutes the database).

🛡️ **Solution:** Added `permission_classes = [permissions.IsAuthenticated]` to the `AddAPIKey` view. Also updated the test suite with `APIClient` to verify that unauthenticated requests fail and authenticated requests succeed.

---
*PR created automatically by Jules for task [8851365904427948760](https://jules.google.com/task/8851365904427948760) started by @bhushanchinmay*